### PR TITLE
Don't destroy website build files before updating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ test: build
 	bundle exec htmlproof $<
 
 build: $(shell find source) Gemfile.lock
-	rm -fr $@
 	bundle exec middleman build --verbose
 
 dev: $(shell find source) Gemfile.lock


### PR DESCRIPTION
The vendored boostrap files not making building more compuationally
expensive. Therefore the `build` directory should not be wiped before
recreating it. Middlemanapp can handle updating only the changed files.

Signed-off-by: Michael Barton mail@michaelbarton.me.uk
