### PR TITLE
Remove duplicate 'container' entry

### DIFF
--- a/source/guide/user/images-vs-containers.mkd
+++ b/source/guide/user/images-vs-containers.mkd
@@ -13,7 +13,7 @@ docker images
 ~~~
 
 When you run a Docker image using `docker run` you are creating a container
-from that instance. This can be illustrated by creating a container container
+from that instance. This can be illustrated by creating a container
 that sleep for 60 seconds. The flag `--detach` means the Docker process will
 run in the background and you may still continue to type in the terminal.
 


### PR DESCRIPTION
The word 'container' is duplicated in this sentence.
